### PR TITLE
Remove dependency of `papyrus/event-sourcing`

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -19,5 +19,6 @@ return (new PhpCsFixer\Config())
         'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
         'php_unit_test_class_requires_covers' => false,
         'phpdoc_order' => true,
+        'phpdoc_align' => ['align' => 'left'],
     ])
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
     "require": {
         "php": "^8.1",
         "jerowork/file-class-reflector": "^0.1",
-        "papyrus/domain-event-registry": "^0.2",
-        "papyrus/event-sourcing": "^0.2",
+        "papyrus/domain-event-registry": "^0.3",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49d7fceda27899f8fbb3b8b68bff130a",
+    "content-hash": "be5389b9806fe18e77efae3ee5f558f1",
     "packages": [
         {
             "name": "doctrine/inflector",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "ade2b3bbfb776f27f0558e26eed43b5d9fe1b392"
+                "reference": "d9d313a36c872fd6ee06d9a6cbcf713eaa40f024"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/ade2b3bbfb776f27f0558e26eed43b5d9fe1b392",
-                "reference": "ade2b3bbfb776f27f0558e26eed43b5d9fe1b392",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/d9d313a36c872fd6ee06d9a6cbcf713eaa40f024",
+                "reference": "d9d313a36c872fd6ee06d9a6cbcf713eaa40f024",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^10",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.3",
@@ -79,7 +79,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.5"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.6"
             },
             "funding": [
                 {
@@ -95,7 +95,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-07T09:01:28+00:00"
+            "time": "2022-10-20T09:10:12+00:00"
         },
         {
             "name": "jerowork/file-class-reflector",
@@ -214,28 +214,31 @@
         },
         {
             "name": "papyrus/domain-event-registry",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/papyrusphp/domain-event-registry.git",
-                "reference": "683df528b3d6babaa0ba2fa36db3741fd69a4da0"
+                "reference": "3ecb91d1fca1ecc8ad399abebefd7361d6f702b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/papyrusphp/domain-event-registry/zipball/683df528b3d6babaa0ba2fa36db3741fd69a4da0",
-                "reference": "683df528b3d6babaa0ba2fa36db3741fd69a4da0",
+                "url": "https://api.github.com/repos/papyrusphp/domain-event-registry/zipball/3ecb91d1fca1ecc8ad399abebefd7361d6f702b1",
+                "reference": "3ecb91d1fca1ecc8ad399abebefd7361d6f702b1",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "^2.0",
-                "papyrus/event-sourcing": "^0.2",
                 "php": "^8.1"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.11",
                 "maglnet/composer-require-checker": "^4.2",
+                "mockery/mockery": "^1.5",
                 "phpro/grumphp-shim": "^1.13",
+                "phpstan/extension-installer": "^1.2",
                 "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.1",
                 "phpunit/phpunit": "^9.5",
                 "scrutinizer/ocular": "^1.9"
             },
@@ -267,96 +270,48 @@
             ],
             "support": {
                 "issues": "https://github.com/papyrusphp/domain-event-registry/issues",
-                "source": "https://github.com/papyrusphp/domain-event-registry/tree/0.2.0"
+                "source": "https://github.com/papyrusphp/domain-event-registry/tree/0.3.0"
             },
-            "time": "2022-10-13T16:47:33+00:00"
-        },
-        {
-            "name": "papyrus/event-sourcing",
-            "version": "0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/papyrusphp/event-sourcing.git",
-                "reference": "b6cbc9fe70c8701d5db36bd4e9bc13c528a08b4d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/papyrusphp/event-sourcing/zipball/b6cbc9fe70c8701d5db36bd4e9bc13c528a08b4d",
-                "reference": "b6cbc9fe70c8701d5db36bd4e9bc13c528a08b4d",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.11",
-                "maglnet/composer-require-checker": "^4.2",
-                "phpro/grumphp-shim": "^1.13",
-                "phpstan/phpstan": "^1.8",
-                "phpunit/phpunit": "^9.5",
-                "scrutinizer/ocular": "^1.9"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Papyrus\\EventSourcing\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jeroen de Graaf",
-                    "email": "hello@jero.work"
-                }
-            ],
-            "description": "Yet another event sourcing library for PHP",
-            "keywords": [
-                "cqrs",
-                "ddd",
-                "domain-driven-design",
-                "event-sourcing",
-                "papyrus"
-            ],
-            "support": {
-                "issues": "https://github.com/papyrusphp/event-sourcing/issues",
-                "source": "https://github.com/papyrusphp/event-sourcing/tree/0.2.0"
-            },
-            "time": "2022-10-13T14:28:19+00:00"
+            "time": "2022-10-21T18:56:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection",
-            "version": "5.2.0",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/Reflection.git",
-                "reference": "936e4dde326e6ba42feb46cb7a89688a9425356f"
+                "reference": "9887ef960405afc97e0e3da48be3656fa4a81a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/936e4dde326e6ba42feb46cb7a89688a9425356f",
-                "reference": "936e4dde326e6ba42feb46cb7a89688a9425356f",
+                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/9887ef960405afc97e0e3da48be3656fa4a81a13",
+                "reference": "9887ef960405afc97e0e3da48be3656fa4a81a13",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^4.13",
-                "php": ">=7.2",
+                "php": "^7.4|8.0.*|8.1.*",
                 "phpdocumentor/reflection-common": "^2.1",
                 "phpdocumentor/reflection-docblock": "^5",
                 "phpdocumentor/type-resolver": "^1.2",
-                "psr/log": "~1.0",
                 "webmozart/assert": "^1.7"
             },
             "require-dev": {
                 "mikey179/vfsstream": "~1.2",
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.5.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-php-parser": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.14.5",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-4.x": "5.0.x-dev"
+                    "dev-5.x": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -378,9 +333,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpDocumentor/Reflection/issues",
-                "source": "https://github.com/phpDocumentor/Reflection/tree/5.2.0"
+                "source": "https://github.com/phpDocumentor/Reflection/tree/5.3.0"
             },
-            "time": "2022-04-02T19:58:37+00:00"
+            "time": "2022-10-14T08:02:22+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -494,25 +449,30 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "77a32518733312af16a44300404e945338981de3"
+                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
-                "reference": "77a32518733312af16a44300404e945338981de3",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
+                "reference": "48f445a408c131e38cab1c235aa6d2bb7a0bb20d",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
             },
             "type": "library",
             "extra": {
@@ -538,59 +498,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.2"
             },
-            "time": "2022-03-15T21:29:03+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
-            "time": "2021-05-03T11:20:27+00:00"
+            "time": "2022-10-14T12:47:21+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -2273,16 +2183,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.10.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "87fa2d526e56737a2ae8fa201a61b15efae59b8a"
+                "reference": "33aefcdab42900e36366d0feab6206e2dd68f947"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/87fa2d526e56737a2ae8fa201a61b15efae59b8a",
-                "reference": "87fa2d526e56737a2ae8fa201a61b15efae59b8a",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/33aefcdab42900e36366d0feab6206e2dd68f947",
+                "reference": "33aefcdab42900e36366d0feab6206e2dd68f947",
                 "shasum": ""
             },
             "require": {
@@ -2312,9 +2222,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.10.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.13.0"
             },
-            "time": "2022-10-12T19:19:18+00:00"
+            "time": "2022-10-21T09:57:39+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -3208,6 +3118,56 @@
                 "source": "https://github.com/php-fig/http-message/tree/master"
             },
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "ralouphie/getallheaders",

--- a/src/Cached/CachedDomainEventClassNameLoaderDecorator.php
+++ b/src/Cached/CachedDomainEventClassNameLoaderDecorator.php
@@ -9,10 +9,18 @@ use Papyrus\ClassReflectionDomainEventRegistry\DomainEventClassNameLoader;
 use Psr\SimpleCache\CacheInterface;
 use Psr\SimpleCache\InvalidArgumentException;
 
+/**
+ * @template DomainEvent of object
+ *
+ * @implements DomainEventClassNameLoader<DomainEvent>
+ */
 final class CachedDomainEventClassNameLoaderDecorator implements DomainEventClassNameLoader
 {
     private const CACHE_KEY = 'papyrus.class-reflection-domain-event-registry';
 
+    /**
+     * @param DomainEventClassNameLoader<DomainEvent> $domainEventClassNameLoader
+     */
     public function __construct(
         private readonly DomainEventClassNameLoader $domainEventClassNameLoader,
         private readonly CacheInterface $cache,

--- a/src/ClassReflectionDomainEventRegistry.php
+++ b/src/ClassReflectionDomainEventRegistry.php
@@ -7,8 +7,12 @@ namespace Papyrus\ClassReflectionDomainEventRegistry;
 use Papyrus\DomainEventRegistry\DomainEventNameResolver\DomainEventNameResolver;
 use Papyrus\DomainEventRegistry\DomainEventNotRegisteredException;
 use Papyrus\DomainEventRegistry\DomainEventRegistry;
-use Papyrus\EventSourcing\DomainEvent;
 
+/**
+ * @template DomainEvent of object
+ *
+ * @implements DomainEventRegistry<DomainEvent>
+ */
 final class ClassReflectionDomainEventRegistry implements DomainEventRegistry
 {
     /**
@@ -16,6 +20,10 @@ final class ClassReflectionDomainEventRegistry implements DomainEventRegistry
      */
     private array $domainEventClassNames = [];
 
+    /**
+     * @param DomainEventClassNameLoader<DomainEvent> $domainEventClassNameLoader
+     * @param DomainEventNameResolver<DomainEvent> $domainEventNameResolver
+     */
     public function __construct(
         private readonly DomainEventClassNameLoader $domainEventClassNameLoader,
         private readonly DomainEventNameResolver $domainEventNameResolver,
@@ -41,9 +49,7 @@ final class ClassReflectionDomainEventRegistry implements DomainEventRegistry
         $classes = $this->domainEventClassNameLoader->load($this->directory);
 
         foreach ($classes as $class) {
-            if (is_subclass_of($class, DomainEvent::class)) {
-                $this->domainEventClassNames[$this->domainEventNameResolver->resolve($class)] = $class;
-            }
+            $this->domainEventClassNames[$this->domainEventNameResolver->resolve($class)] = $class;
         }
     }
 }

--- a/src/DomainEventClassNameLoader.php
+++ b/src/DomainEventClassNameLoader.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Papyrus\ClassReflectionDomainEventRegistry;
 
-use Papyrus\EventSourcing\DomainEvent;
-
+/**
+ * @template DomainEvent of object
+ */
 interface DomainEventClassNameLoader
 {
     /**

--- a/src/FileClassReflector/FileClassReflectorDomainEventClassNameLoader.php
+++ b/src/FileClassReflector/FileClassReflectorDomainEventClassNameLoader.php
@@ -6,8 +6,12 @@ namespace Papyrus\ClassReflectionDomainEventRegistry\FileClassReflector;
 
 use Jerowork\FileClassReflector\ClassReflectorFactory;
 use Papyrus\ClassReflectionDomainEventRegistry\DomainEventClassNameLoader;
-use Papyrus\EventSourcing\DomainEvent;
 
+/**
+ * @template DomainEvent of object
+ *
+ * @implements DomainEventClassNameLoader<DomainEvent>
+ */
 final class FileClassReflectorDomainEventClassNameLoader implements DomainEventClassNameLoader
 {
     public function __construct(
@@ -20,7 +24,7 @@ final class FileClassReflectorDomainEventClassNameLoader implements DomainEventC
         $reflector = $this->classReflectorFactory->create()->addDirectory($directory);
         $domainEventClassNames = [];
         foreach ($reflector->reflect()->getClasses() as $class) {
-            if ($class->implementsInterface(DomainEvent::class) === false) {
+            if (str_ends_with($class->getName(), 'Event') === false) {
                 continue;
             }
 

--- a/tests/Cached/CachedDomainEventClassNameLoaderDecoratorTest.php
+++ b/tests/Cached/CachedDomainEventClassNameLoaderDecoratorTest.php
@@ -18,7 +18,7 @@ use Psr\SimpleCache\CacheInterface;
 class CachedDomainEventClassNameLoaderDecoratorTest extends MockeryTestCase
 {
     /**
-     * @var MockInterface&DomainEventClassNameLoader
+     * @var MockInterface&DomainEventClassNameLoader<object>
      */
     private MockInterface $domainEventClassNameLoader;
 
@@ -27,6 +27,9 @@ class CachedDomainEventClassNameLoaderDecoratorTest extends MockeryTestCase
      */
     private MockInterface $cache;
 
+    /**
+     * @var CachedDomainEventClassNameLoaderDecorator<object>
+     */
     private CachedDomainEventClassNameLoaderDecorator $decorator;
 
     protected function setUp(): void

--- a/tests/ClassReflectionDomainEventRegistryTest.php
+++ b/tests/ClassReflectionDomainEventRegistryTest.php
@@ -10,7 +10,7 @@ use Mockery\MockInterface;
 use Papyrus\ClassReflectionDomainEventRegistry\ClassReflectionDomainEventRegistry;
 use Papyrus\ClassReflectionDomainEventRegistry\DomainEventClassNameLoader;
 use Papyrus\ClassReflectionDomainEventRegistry\Test\FileClassReflector\Stub\TestDomainEvent;
-use Papyrus\DomainEventRegistry\DomainEventNameResolver\NamedDomainEvent\NamedDomainEventNameResolver;
+use Papyrus\DomainEventRegistry\DomainEventNameResolver\DomainEventNameResolver;
 use Papyrus\DomainEventRegistry\DomainEventNotRegisteredException;
 
 /**
@@ -19,17 +19,25 @@ use Papyrus\DomainEventRegistry\DomainEventNotRegisteredException;
 class ClassReflectionDomainEventRegistryTest extends MockeryTestCase
 {
     /**
-     * @var MockInterface&DomainEventClassNameLoader
+     * @var MockInterface&DomainEventClassNameLoader<object>
      */
     private MockInterface $domainEventClassNameLoader;
 
+    /**
+     * @var MockInterface&DomainEventNameResolver<object>
+     */
+    private MockInterface $resolver;
+
+    /**
+     * @var ClassReflectionDomainEventRegistry<object>
+     */
     private ClassReflectionDomainEventRegistry $domainEventRegistry;
 
     protected function setUp(): void
     {
         $this->domainEventRegistry = new ClassReflectionDomainEventRegistry(
             $this->domainEventClassNameLoader = Mockery::mock(DomainEventClassNameLoader::class),
-            new NamedDomainEventNameResolver(),
+            $this->resolver = Mockery::mock(DomainEventNameResolver::class),
             'some-dir',
         );
 
@@ -45,6 +53,11 @@ class ClassReflectionDomainEventRegistryTest extends MockeryTestCase
             TestDomainEvent::class,
         ]);
 
+        $this->resolver->expects('resolve')
+            ->with(TestDomainEvent::class)
+            ->andReturn('test.domain_event')
+        ;
+
         $domainEventClassName = $this->domainEventRegistry->retrieve('test.domain_event');
 
         self::assertSame(TestDomainEvent::class, $domainEventClassName);
@@ -58,6 +71,11 @@ class ClassReflectionDomainEventRegistryTest extends MockeryTestCase
         $this->domainEventClassNameLoader->expects('load')->once()->andReturn([
             TestDomainEvent::class,
         ]);
+
+        $this->resolver->expects('resolve')
+            ->with(TestDomainEvent::class)
+            ->andReturn('test.domain_event')
+        ;
 
         $domainEventClassName = $this->domainEventRegistry->retrieve('test.domain_event');
 
@@ -76,6 +94,11 @@ class ClassReflectionDomainEventRegistryTest extends MockeryTestCase
         $this->domainEventClassNameLoader->expects('load')->andReturn([
             TestDomainEvent::class,
         ]);
+
+        $this->resolver->expects('resolve')
+            ->with(TestDomainEvent::class)
+            ->andReturn('test.domain_event')
+        ;
 
         self::expectException(DomainEventNotRegisteredException::class);
 

--- a/tests/FileClassReflector/FileClassReflectorDomainEventClassNameLoaderTest.php
+++ b/tests/FileClassReflector/FileClassReflectorDomainEventClassNameLoaderTest.php
@@ -10,7 +10,7 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Mockery\MockInterface;
 use Papyrus\ClassReflectionDomainEventRegistry\FileClassReflector\FileClassReflectorDomainEventClassNameLoader;
 use Papyrus\ClassReflectionDomainEventRegistry\Test\FileClassReflector\Stub\TestDomainEvent;
-use Papyrus\ClassReflectionDomainEventRegistry\Test\FileClassReflector\Stub\TestNonDomainEvent;
+use Papyrus\ClassReflectionDomainEventRegistry\Test\FileClassReflector\Stub\TestAnotherDomainEvent;
 use ReflectionClass;
 
 /**
@@ -23,6 +23,9 @@ class FileClassReflectorDomainEventClassNameLoaderTest extends MockeryTestCase
      */
     private MockInterface $classReflectorFactory;
 
+    /**
+     * @var FileClassReflectorDomainEventClassNameLoader<object>
+     */
     private FileClassReflectorDomainEventClassNameLoader $loader;
 
     protected function setUp(): void
@@ -43,7 +46,7 @@ class FileClassReflectorDomainEventClassNameLoaderTest extends MockeryTestCase
             ->expects('create->addDirectory->reflect->getClasses')
             ->andReturn([
                 new ReflectionClass(TestDomainEvent::class),
-                new ReflectionClass(TestNonDomainEvent::class),
+                new ReflectionClass(TestAnotherDomainEvent::class),
             ])
         ;
 
@@ -51,6 +54,7 @@ class FileClassReflectorDomainEventClassNameLoaderTest extends MockeryTestCase
 
         self::assertSame([
             TestDomainEvent::class,
+            TestAnotherDomainEvent::class,
         ], $classNames);
     }
 }

--- a/tests/FileClassReflector/Stub/TestAnotherDomainEvent.php
+++ b/tests/FileClassReflector/Stub/TestAnotherDomainEvent.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Papyrus\ClassReflectionDomainEventRegistry\Test\FileClassReflector\Stub;
 
-final class TestNonDomainEvent
+final class TestAnotherDomainEvent
 {
 }

--- a/tests/FileClassReflector/Stub/TestDomainEvent.php
+++ b/tests/FileClassReflector/Stub/TestDomainEvent.php
@@ -4,18 +4,10 @@ declare(strict_types=1);
 
 namespace Papyrus\ClassReflectionDomainEventRegistry\Test\FileClassReflector\Stub;
 
-use Papyrus\DomainEventRegistry\DomainEventNameResolver\NamedDomainEvent;
-use Papyrus\EventSourcing\DomainEvent;
-
-final class TestDomainEvent implements DomainEvent, NamedDomainEvent
+final class TestDomainEvent
 {
     public static function getEventName(): string
     {
         return 'test.domain_event';
-    }
-
-    public function getAggregateRootId(): string
-    {
-        return '';
     }
 }


### PR DESCRIPTION
Your domain layer should not rely on external code. Therefore the library
`papyrus/event-sourcing` should not be used as vendor, instead copy or build
your own. All papyrus libraries should therefore not rely on this library.